### PR TITLE
fix missing booking API route

### DIFF
--- a/back/src/app.ts
+++ b/back/src/app.ts
@@ -5,12 +5,12 @@ import { connectDB } from './infrastructure/database/mongoConnection';
 import { expressErrorHandler } from './infrastructure/web/expressErrorHandler';
 import { setupSwagger } from './infrastructure/web/swaggerConfig';
 import passport from './infrastructure/web/passportConfig';
-import { authMiddleware } from './infrastructure/web/authMiddleware';
 import { loggerMiddleware } from './interfaces/http/middlewares/loggerMiddleware';
 
 import hotelRoutes from './interfaces/http/routes/hotelRoutes';
 import roomRoutes from './interfaces/http/routes/roomRoutes';
 import authRoutes from './interfaces/http/routes/authRoutes';
+import bookingRoutes from './interfaces/http/routes/bookingRoutes';
 
 const app = express();
 
@@ -33,6 +33,7 @@ app.get('/', (req, res) => {
 app.use('/api/v1/hotels', hotelRoutes);
 app.use('/api/v1/rooms', roomRoutes);
 app.use('/api/v1/auth', authRoutes);
+app.use('/api/v1/bookings', bookingRoutes);
 
 app.use(expressErrorHandler);
 


### PR DESCRIPTION
## Summary
- wire up bookingRoutes in Express app so reservation POSTs succeed

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b3f92fb45c8330a7a198a472af3d34