### PR TITLE
Fix booking auth token handling and validation

### DIFF
--- a/back/src/interfaces/http/controllers/bookingController.ts
+++ b/back/src/interfaces/http/controllers/bookingController.ts
@@ -15,10 +15,20 @@ export class BookingController {
         private cancelBookingUseCase: CancelBookingUseCase
     ) {}
 
-    async createBooking(req: Request<{}, {}, CreateBookingRequest>, res: Response<BookingResponse>, next: NextFunction) {
+    async createBooking(
+        req: Request<{}, {}, CreateBookingRequest>,
+        res: Response<BookingResponse | { message: string }>,
+        next: NextFunction
+    ) {
         try {
+            const user = (req as any).user;
+            if (!user?.id) {
+                return res.status(401).json({ message: 'Unauthorized' });
+            }
+
             const bookingData = {
                 ...req.body,
+                userId: user.id,
                 checkInDate: new Date(req.body.checkInDate),
                 checkOutDate: new Date(req.body.checkOutDate)
             };

--- a/front/app/src/app/core/interceptors/auth-interceptor.ts
+++ b/front/app/src/app/core/interceptors/auth-interceptor.ts
@@ -1,17 +1,26 @@
 import { Injectable, Inject, PLATFORM_ID } from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
-import { HttpInterceptor, HttpRequest, HttpHandler, HttpEvent } from '@angular/common/http';
+import {
+  HttpInterceptor,
+  HttpRequest,
+  HttpHandler,
+  HttpEvent
+} from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { AuthService } from '../services/auth-service';
 
 @Injectable({
   providedIn: 'root'
 })
 export class AuthInterceptor implements HttpInterceptor {
-  constructor(@Inject(PLATFORM_ID) private platformId: Object) {}
+  constructor(
+    @Inject(PLATFORM_ID) private platformId: Object,
+    private authService: AuthService
+  ) {}
 
   intercept(req: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
     const token: string | null = isPlatformBrowser(this.platformId)
-      ? localStorage.getItem('token')
+      ? this.authService.getToken()
       : null;
 
     const isAuthEndpoint: boolean = req.url.includes('/auth/login') || req.url.includes('/auth/register');

--- a/front/app/src/app/features/hotel/pages/hotel-booking/hotel-booking.ts
+++ b/front/app/src/app/features/hotel/pages/hotel-booking/hotel-booking.ts
@@ -255,7 +255,7 @@ export class HotelBookingComponent implements OnInit, OnDestroy, CanComponentDea
   onBook() {
     if (!this.authService.isLoggedIn()) {
       this.saveBookingState();
-      this.error.set('Por favor, inicia sesión para continuar con tu reserva.');
+      this.errorMessage.set('Por favor, inicia sesión para continuar con tu reserva.');
       return;
     }
     this.showBookingModal.set(true);

--- a/front/app/src/app/features/hotel/services/reservation-service.ts
+++ b/front/app/src/app/features/hotel/services/reservation-service.ts
@@ -78,6 +78,8 @@ export class ReservationService {
     if (error.status === 400) {
       errorMessage =
         'No se puede cancelar: la fecha de cancelación ha expirado (debe ser 3 días antes)';
+    } else if (error.status === 401) {
+      errorMessage = 'No autorizado. Por favor, inicia sesión.';
     } else if (error.status === 404) {
       errorMessage = 'Reserva no encontrada';
     } else if (error.status === 500) {


### PR DESCRIPTION
## Summary
- attach stored auth token to booking API requests via interceptor
- surface login requirement via modal when booking without token and handle 401 errors
- validate JWT on backend bookings using token's user id

## Testing
- `npm run build` (backend)
- `npm run build` (frontend) *(fails: css budgets & missing getPrerenderParams)*

------
https://chatgpt.com/codex/tasks/task_e_68b3fcadb878833093fa7e18bef78303