### PR TITLE
feat: add auth token interceptor with modal

### DIFF
--- a/front/app/src/app/app.config.ts
+++ b/front/app/src/app/app.config.ts
@@ -1,13 +1,13 @@
 import { ApplicationConfig, provideBrowserGlobalErrorListeners, provideZoneChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
-import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
 import { provideClientHydration, withEventReplay } from '@angular/platform-browser';
 
 import { routes } from './app.routes';
 
 export const appConfig: ApplicationConfig = {
   providers: [
-    provideHttpClient(),
+    provideHttpClient(withInterceptorsFromDi()),
     provideBrowserGlobalErrorListeners(),
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideRouter(routes), 

--- a/front/app/src/app/app.html
+++ b/front/app/src/app/app.html
@@ -3,3 +3,8 @@
   <router-outlet></router-outlet>
 </main>
 <app-footer></app-footer>
+<app-reservation-error-modal
+  *ngIf="unauthorizedModalService.message() as msg"
+  [message]="msg"
+  (close)="unauthorizedModalService.close()"
+></app-reservation-error-modal>

--- a/front/app/src/app/app.ts
+++ b/front/app/src/app/app.ts
@@ -1,13 +1,16 @@
 import { Component, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
 import { HeaderComponent } from './core/components/header/header';
 import { FooterComponent } from './core/components/footer/footer';
 import { RouterOutlet } from '@angular/router';
+import { UnauthorizedModalService } from './core/services/unauthorized-modal-service';
+import { ReservationErrorModalComponent } from './shared/components/reservation-error-modal/reservation-error-modal';
 
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [HeaderComponent, FooterComponent, RouterOutlet],
+  imports: [CommonModule, HeaderComponent, FooterComponent, RouterOutlet, ReservationErrorModalComponent],
 
   templateUrl: './app.html',
   styleUrl: './app.scss'
@@ -15,7 +18,9 @@ import { RouterOutlet } from '@angular/router';
 export class App {
   protected readonly title = signal('Hotel Booking App');
   currentCurrency = signal('BOB');
-  
+
+  constructor(public unauthorizedModalService: UnauthorizedModalService) {}
+
   onCurrencyChange(currency: string) {
     this.currentCurrency.set(currency);
   }

--- a/front/app/src/app/core/services/auth-service.ts
+++ b/front/app/src/app/core/services/auth-service.ts
@@ -24,7 +24,7 @@ export interface AuthResponse {
   providedIn: 'root'
 })
 export class AuthService {
-  private readonly TOKEN_KEY = 'auth_token';
+  private readonly TOKEN_KEY = 'access_token';
   private readonly USER_KEY = 'auth_user';
   private readonly EXPIRY_KEY = 'auth_expiry';
   private readonly TOKEN_DURATION = 60 * 60 * 1000

--- a/front/app/src/app/core/services/unauthorized-modal-service.ts
+++ b/front/app/src/app/core/services/unauthorized-modal-service.ts
@@ -1,0 +1,17 @@
+import { Injectable, signal } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class UnauthorizedModalService {
+  message = signal<string | null>(null);
+
+  show(message: string): void {
+    this.message.set(message);
+  }
+
+  close(): void {
+    this.message.set(null);
+  }
+}
+


### PR DESCRIPTION
## Summary
- send access token in Authorization header through new HTTP interceptor
- show login prompt modal when token is missing or unauthorized
- wire up interceptor into Angular config and expose modal via root app

## Testing
- No tests were run as per user request

------
https://chatgpt.com/codex/tasks/task_e_68b3fee04968833099de5497f7969b19