### PR TITLE
feat: add user reservations management

### DIFF
--- a/front/app/src/app/core/components/header/header.html
+++ b/front/app/src/app/core/components/header/header.html
@@ -42,6 +42,11 @@
                 Configuración
               </button>
 
+              <button class="profile__item" (click)="openReservationsModal()">
+                <i class="fas fa-calendar-check"></i>
+                Mis reservas
+              </button>
+
               <button class="profile__item" (click)="onLogout()">
                 <i class="fas fa-sign-out-alt"></i>
                 Cerrar sesión
@@ -95,6 +100,22 @@
           <i class="fas fa-check-circle success-icon"></i>
           <h3>Inicio de sesión exitoso</h3>
           <p>¡Bienvenido, {{ currentUser()?.username }}!</p>
+        </div>
+      </div>
+    </div>
+  }
+
+  @if (isReservationsModalOpen()) {
+    <div class="reservations-modal-backdrop" (click)="onReservationsBackdropClick($event)">
+      <div class="reservations-modal-container">
+        <div class="reservations-modal-header">
+          <h2>Mis Reservas</h2>
+          <button class="reservations-modal-close" (click)="closeReservationsModal()">
+            <i class="fas fa-times"></i>
+          </button>
+        </div>
+        <div class="reservations-modal-content">
+          <app-user-reservations></app-user-reservations>
         </div>
       </div>
     </div>

--- a/front/app/src/app/core/components/header/header.scss
+++ b/front/app/src/app/core/components/header/header.scss
@@ -394,6 +394,68 @@
   animation: slideUp 0.3s ease-out;
 }
 
+.reservations-modal-backdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(32, 32, 32, 0.8);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 2000;
+  animation: fadeIn 0.3s ease-out;
+}
+
+.reservations-modal-container {
+  background: white;
+  border-radius: 16px;
+  box-shadow: 0 20px 40px rgba(55, 15, 65, 0.3);
+  width: 90%;
+  max-width: 600px;
+  max-height: 90vh;
+  overflow-y: auto;
+  animation: slideUp 0.4s ease-out;
+}
+
+.reservations-modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 20px 24px;
+  border-bottom: 1px solid #F5F5F5;
+
+  h2 {
+    margin: 0;
+    font-size: 20px;
+    font-weight: 700;
+    color: #370F41;
+    font-family: var(--font-family);
+  }
+}
+
+.reservations-modal-close {
+  background: none;
+  border: none;
+  color: #808080;
+  font-size: 18px;
+  cursor: pointer;
+  padding: 8px;
+  border-radius: 50%;
+  transition: all 0.3s ease;
+  margin-left: auto;
+
+  &:hover {
+    background: #F5F5F5;
+    color: #370F41;
+  }
+}
+
+.reservations-modal-content {
+  padding: 0;
+}
+
 .success-modal-header {
   display: flex;
   justify-content: flex-end;

--- a/front/app/src/app/core/components/header/header.ts
+++ b/front/app/src/app/core/components/header/header.ts
@@ -1,13 +1,14 @@
 import { Component, signal, OnInit, OnDestroy, Inject } from '@angular/core';
 import { Router, RouterModule } from '@angular/router';
 import { LoginForm } from '../../../features/auth/components/login-form/login-form';
+import { UserReservationsComponent } from '../../../features/hotel/components/user-reservations/user-reservations';
 import { AuthService, User } from '../../services/auth-service';
 import { Subject, takeUntil } from 'rxjs';
 
 @Component({
   selector: 'app-header',
   standalone: true,
-  imports: [LoginForm, RouterModule],
+  imports: [LoginForm, UserReservationsComponent, RouterModule],
   templateUrl: './header.html',
   styleUrl: './header.scss'
 })
@@ -20,6 +21,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
   currentUser = signal<{username: string} | null>(null);
   isProfileMenuOpen = signal(false);
   isSuccessModalOpen = signal(false);
+  isReservationsModalOpen = signal(false);
 
   constructor(
     @Inject(AuthService) private authService: AuthService,
@@ -103,6 +105,23 @@ export class HeaderComponent implements OnInit, OnDestroy {
   onSuccessBackdropClick(event: Event) {
     if (event.target === event.currentTarget) {
       this.closeSuccessModal();
+    }
+  }
+
+  openReservationsModal() {
+    this.isReservationsModalOpen.set(true);
+    this.isProfileMenuOpen.set(false);
+    document.body.style.overflow = 'hidden';
+  }
+
+  closeReservationsModal() {
+    this.isReservationsModalOpen.set(false);
+    document.body.style.overflow = 'auto';
+  }
+
+  onReservationsBackdropClick(event: Event) {
+    if (event.target === event.currentTarget) {
+      this.closeReservationsModal();
     }
   }
 }

--- a/front/app/src/app/features/hotel/components/user-reservations/user-reservations.html
+++ b/front/app/src/app/features/hotel/components/user-reservations/user-reservations.html
@@ -1,0 +1,24 @@
+<div class="reservations" *ngIf="!isLoading(); else loading">
+  <ng-container *ngIf="reservations().length; else noData">
+    <div class="reservation-card" *ngFor="let r of reservations()">
+      <div class="reservation-card__info">
+        <p><strong>Hotel:</strong> {{ r.hotelId }}</p>
+        <p><strong>Check-in:</strong> {{ r.checkInDate | date }}</p>
+        <p><strong>Check-out:</strong> {{ r.checkOutDate | date }}</p>
+        <p><strong>Huéspedes:</strong> {{ r.numberOfGuests }}</p>
+        <p><strong>Total:</strong> {{ r.totalPrice | currency }}</p>
+      </div>
+      <button class="reservation-card__cancel"
+              (click)="cancelReservation(r)"
+              [disabled]="!canCancel(r)">
+        Cancelar
+      </button>
+    </div>
+  </ng-container>
+</div>
+<ng-template #loading>
+  <div class="reservations__loading">Cargando...</div>
+</ng-template>
+<ng-template #noData>
+  <div class="reservations__empty">No tienes reservas.</div>
+</ng-template>

--- a/front/app/src/app/features/hotel/components/user-reservations/user-reservations.scss
+++ b/front/app/src/app/features/hotel/components/user-reservations/user-reservations.scss
@@ -1,0 +1,45 @@
+.reservations {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  font-family: var(--font-family);
+}
+
+.reservation-card {
+  border: 1px solid #F5F5F5;
+  border-radius: 8px;
+  padding: 12px;
+  background: #ffffff;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+
+  &__cancel {
+    align-self: flex-start;
+    background: #7977AD;
+    color: #ffffff;
+    border: none;
+    padding: 6px 12px;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 13px;
+    transition: background 0.2s ease;
+
+    &:hover:not(:disabled) {
+      background: #6b6999;
+    }
+
+    &:disabled {
+      background: #cccccc;
+      cursor: not-allowed;
+    }
+  }
+}
+
+.reservations__loading,
+.reservations__empty {
+  padding: 16px;
+  text-align: center;
+  color: #370F41;
+}

--- a/front/app/src/app/features/hotel/components/user-reservations/user-reservations.ts
+++ b/front/app/src/app/features/hotel/components/user-reservations/user-reservations.ts
@@ -1,0 +1,69 @@
+import { Component, OnInit, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReservationService } from '../../services/reservation-service';
+import { AuthService } from '../../../../core/services/auth-service';
+import { Booking } from '../../../../shared/models/booking-model';
+
+@Component({
+  selector: 'app-user-reservations',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './user-reservations.html',
+  styleUrl: './user-reservations.scss'
+})
+export class UserReservationsComponent implements OnInit {
+  reservations = signal<Booking[]>([]);
+  isLoading = signal(false);
+  error = signal('');
+
+  constructor(
+    private reservationService: ReservationService,
+    private authService: AuthService
+  ) {}
+
+  ngOnInit() {
+    this.loadReservations();
+  }
+
+  private loadReservations() {
+    const user = this.authService.getCurrentUser();
+    if (!user) {
+      this.error.set('Debes iniciar sesión para ver tus reservas.');
+      return;
+    }
+
+    this.isLoading.set(true);
+    this.reservationService.getUserReservations(user.id).subscribe({
+      next: (res) => {
+        this.reservations.set(res);
+        this.isLoading.set(false);
+      },
+      error: (err) => {
+        this.error.set(err.message);
+        this.isLoading.set(false);
+      }
+    });
+  }
+
+  canCancel(reservation: Booking): boolean {
+    return (
+      reservation.isActive &&
+      this.reservationService.canCancelReservation(reservation.checkInDate)
+    );
+  }
+
+  cancelReservation(reservation: Booking) {
+    if (!this.canCancel(reservation)) {
+      return;
+    }
+
+    this.reservationService.cancelReservation(reservation.id).subscribe({
+      next: () => {
+        this.reservations.update((list) =>
+          list.filter((r) => r.id !== reservation.id)
+        );
+      },
+      error: (err) => this.error.set(err.message)
+    });
+  }
+}

--- a/front/app/src/app/features/hotel/services/reservation-service.ts
+++ b/front/app/src/app/features/hotel/services/reservation-service.ts
@@ -31,8 +31,10 @@ export class ReservationService {
    * Retrieves all reservations
    */
   getReservations(): Observable<Booking[]> {
+    const token = this.authService.getToken();
+    const headers = token ? { Authorization: `Bearer ${token}` } : undefined;
     return this.http
-      .get<Booking[]>(this.baseUrl)
+      .get<Booking[]>(this.baseUrl, { headers })
       .pipe(catchError(this.handleError));
   }
 
@@ -40,8 +42,10 @@ export class ReservationService {
    * Retrieves reservations for a specific user
    */
   getUserReservations(userId: string): Observable<Booking[]> {
+    const token = this.authService.getToken();
+    const headers = token ? { Authorization: `Bearer ${token}` } : undefined;
     return this.http
-      .get<Booking[]>(`${this.baseUrl}?userId=${userId}`)
+      .get<Booking[]>(`${this.baseUrl}?userId=${userId}`, { headers })
       .pipe(catchError(this.handleError));
   }
 
@@ -49,8 +53,10 @@ export class ReservationService {
    * Retrieves a single reservation by id
    */
   getReservationById(id: string): Observable<Booking> {
+    const token = this.authService.getToken();
+    const headers = token ? { Authorization: `Bearer ${token}` } : undefined;
     return this.http
-      .get<Booking>(`${this.baseUrl}/${id}`)
+      .get<Booking>(`${this.baseUrl}/${id}`, { headers })
       .pipe(catchError(this.handleError));
   }
 
@@ -58,8 +64,10 @@ export class ReservationService {
    * Cancels an existing reservation
    */
   cancelReservation(id: string): Observable<Booking> {
+    const token = this.authService.getToken();
+    const headers = token ? { Authorization: `Bearer ${token}` } : undefined;
     return this.http
-      .patch<Booking>(`${this.baseUrl}/${id}/cancel`, {})
+      .patch<Booking>(`${this.baseUrl}/${id}/cancel`, {}, { headers })
       .pipe(catchError(this.handleError));
   }
 


### PR DESCRIPTION
## Summary
- allow users to view and cancel their own reservations
- secure reservation requests with auth tokens

## Testing
- `npm run build` *(front, fails: css budget and prerender params)*
- `npm run build` (back)
- `npm test` *(back, fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b4bc0dd9f48330aa3fed66b4d2c948