### PR TITLE
fix: hide cancelled reservations and confirm cancellation

### DIFF
--- a/front/app/src/app/features/hotel/components/user-reservations/user-reservations.html
+++ b/front/app/src/app/features/hotel/components/user-reservations/user-reservations.html
@@ -1,4 +1,8 @@
 <div class="reservations" *ngIf="!isLoading(); else loading">
+  <div class="reservations__message" *ngIf="successMessage()">
+    {{ successMessage() }}
+  </div>
+  <div class="reservations__error" *ngIf="error()">{{ error() }}</div>
   <ng-container *ngIf="reservations().length; else noData">
     <div class="reservation-card" *ngFor="let r of reservations()">
       <div class="reservation-card__info">

--- a/front/app/src/app/features/hotel/components/user-reservations/user-reservations.scss
+++ b/front/app/src/app/features/hotel/components/user-reservations/user-reservations.scss
@@ -43,3 +43,15 @@
   text-align: center;
   color: #370F41;
 }
+
+.reservations__message {
+  padding: 16px;
+  text-align: center;
+  color: #2e7d32;
+}
+
+.reservations__error {
+  padding: 16px;
+  text-align: center;
+  color: #c62828;
+}

--- a/front/app/src/app/features/hotel/components/user-reservations/user-reservations.ts
+++ b/front/app/src/app/features/hotel/components/user-reservations/user-reservations.ts
@@ -15,6 +15,7 @@ export class UserReservationsComponent implements OnInit {
   reservations = signal<Booking[]>([]);
   isLoading = signal(false);
   error = signal('');
+  successMessage = signal('');
 
   constructor(
     private reservationService: ReservationService,
@@ -62,6 +63,7 @@ export class UserReservationsComponent implements OnInit {
         this.reservations.update((list) =>
           list.filter((r) => r.id !== reservation.id)
         );
+        this.successMessage.set('Reserva cancelada exitosamente.');
       },
       error: (err) => this.error.set(err.message)
     });

--- a/front/app/src/app/features/hotel/services/reservation-service.ts
+++ b/front/app/src/app/features/hotel/services/reservation-service.ts
@@ -45,7 +45,9 @@ export class ReservationService {
     const token = this.authService.getToken();
     const headers = token ? { Authorization: `Bearer ${token}` } : undefined;
     return this.http
-      .get<Booking[]>(`${this.baseUrl}?userId=${userId}`, { headers })
+      .get<Booking[]>(`${this.baseUrl}?userId=${userId}&isActive=true`, {
+        headers
+      })
       .pipe(catchError(this.handleError));
   }
 


### PR DESCRIPTION
## Summary
- show cancellation success message in user reservations
- request only active bookings from API so cancelled ones disappear

## Testing
- `npm test` (frontend, fails: Module has no exported member)
- `npm test` (backend, fails: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68b4bec0d9488330945568be53383ddb